### PR TITLE
get_context_instance() replaced with context_module::instance()

### DIFF
--- a/view.php
+++ b/view.php
@@ -120,7 +120,7 @@ ini_set('arg_separator.output', $separator);
 
 // [END] Etherpad Lite init
 
-$context = get_context_instance(CONTEXT_MODULE, $cm->id);
+$context = context_module::instance($cm->id);
 
 /// Print the page header
 $PAGE->set_title("Etherpad Lite: ".format_string($etherpadlite->name));


### PR DESCRIPTION
get_context_instance() is marked as deprecated, and has to be avoided.

```
modified:   view.php
```
