### PR TITLE
Fixes #11: Wrong argument for moodle_database::get_record()

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@ require_once(dirname(__FILE__).'/lib.php');
 
 $id = required_param('id', PARAM_INT);   // course
 
-if (! $course = $DB->get_record('course', 'id', $id)) {
+if (! $course = $DB->get_record('course', array('id' => $id)) {
     error('Course ID is incorrect');
 }
 


### PR DESCRIPTION
The call of moodle_database::get_record() was deprecated in `index.php` at line 19.

	modified:   index.php