### PR TITLE
DefaultPadTexts are now showing up again when a pad is created

### DIFF
--- a/classes/client.php
+++ b/classes/client.php
@@ -161,12 +161,16 @@ class client {
     }
 
     // Creates a new pad in this group.
-    public function create_group_pad($groupid, $padname, $text = null) {
-        $pad = $this->post('createGroupPad', [
-            'groupID' => $groupid,
-            'padName' => $padname,
-            'text' => $text
-        ]);
+    public function create_group_pad($groupid, $padname) {
+        $postParameters =  [
+                'groupID' => $groupid,
+                'padName' => $padname
+        ];
+
+        $defaultpadtext = get_config('etherpadlite', 'defaultpadtext');
+        empty($defaultpadtext) ? null : $postParameters['text'] = $defaultpadtext;
+
+        $pad = $this->post('createGroupPad', $postParameters);
         if ($pad) {
             return $pad->padID;
         }

--- a/lang/en/etherpadlite.php
+++ b/lang/en/etherpadlite.php
@@ -60,3 +60,5 @@ $string['urldesc'] = 'This is the URL to your Etherpadlite server in the form: h
 $string['ssl'] = 'HTTPS Redirect';
 $string['ssldesc'] = 'With this set, your site will redirect itself to HTTPS, if an etherpadlite is opened (eye candy for the user)';
 $string['summaryguest'] = 'You are logged in as guest. That\'s why you can only see the readonly version of this Pad. Reload the page to get new changes.';
+$string['defaultpadtext'] = 'Default pad text';
+$string['defaultpadtextdesc'] = 'This is the default text that will be inserted into newly created pads. This overrides the text from the \'defaultPadText\' setting of your etherpadlite server. Leave it empty to use the setting of your server.';

--- a/settings.php
+++ b/settings.php
@@ -53,3 +53,6 @@ $settings->add(new admin_setting_configcheckbox('etherpadlite/responsiveiframe',
 
 $settings->add(new admin_setting_configtext('etherpadlite/minwidth', get_string('minwidth', 'etherpadlite'),
                    get_string('minwidthdesc', 'etherpadlite'), '400', PARAM_INT));
+
+$settings->add(new admin_setting_configtextarea('etherpadlite/defaultpadtext', get_string('defaultpadtext', 'etherpadlite'),
+                   get_string('defaultpadtextdesc', 'etherpadlite'), "", PARAM_TEXT));

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version    = 2019013100;  // The current module version (Date: YYYYMMDDXX).
+$plugin->version    = 2020122100;  // The current module version (Date: YYYYMMDDXX).
 $plugin->requires   = 2018050800;
 $plugin->cron       = 0;           // Period for cron to check this module (secs).
 $plugin->component  = 'mod_etherpadlite';


### PR DESCRIPTION
This should resolve the issue where the text set with`defaultPadText` would not show up on freshly created pads. It also makes the text appear in pads created by the 'duplicate' functionality provided by moodle.