### PR TITLE
readonly url and groupmode fix

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -360,7 +360,7 @@ function etherpadlite_gen_random_string() {
     $characters = "0123456789";
     $string = "";
     for ($p = 0; $p < $length; $p++) {
-        $string .= $characters[mt_rand(0, strlen($characters))];
+        $string .= $characters[mt_rand(0, strlen($characters) - 1)];
     }
     return $string;
 }


### PR DESCRIPTION
Fixed an error in the url creation for read only pads and added a check to control if a user is part of a certain group.
More details:
- The URL generated for a readonly pad is built like .../ro/readonlyid but has to look like .../p/readonly to work.
- There is no check if a user is part of a group if hes trying to access a group pad. So he could edit every pad even if hes in a different group within the activity.