### PR TITLE
fix: issue 56, loading locallib

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -109,8 +109,8 @@ function etherpadlite_add_instance(stdClass $etherpadlite, mod_etherpadlite_mod_
  * @return boolean Success/Fail
  */
 function etherpadlite_update_instance(stdClass $etherpadlite, mod_etherpadlite_mod_form $mform = null) {
-    global $DB;
-    require_once('locallib.php');
+    global $DB, $CFG;
+    require_once($CFG->dirroot.'/mod/etherpadlite/locallib.php');
 
     $etherpadlite->timemodified = time();
     $etherpadlite->id = $etherpadlite->instance;
@@ -147,8 +147,8 @@ function etherpadlite_update_instance(stdClass $etherpadlite, mod_etherpadlite_m
  */
 function etherpadlite_delete_instance($id) {
 
-    global $DB;
-    require_once('locallib.php');
+    global $DB, $CFG;
+    require_once($CFG->dirroot.'/mod/etherpadlite/locallib.php');
 
     if (! $etherpadlite = $DB->get_record('etherpadlite', array('id' => $id))) {
         return false;


### PR DESCRIPTION
This PR provide a better solution to require file `locallib.php`.

This will solve the [issue 56](https://github.com/moodlehu/moodle-mod_etherpadlite/issues/56).

This solution is used in others plugins to cleanly require a file.