### PR TITLE
Fix client construtor

### DIFF
--- a/classes/api/client.php
+++ b/classes/api/client.php
@@ -77,7 +77,7 @@ class client {
         $this->apiurl = $this->baseurl . '/api';
 
         // Sometimes the etherpad host is located on an internal network like 127.0.0.1 or 10.0.0.0/8.
-        // Since Moodle 4.0 this kind of host are blocked by default.
+        // Since Moodle 4.0 these kinds of hosts are blocked by default.
         $settings = [];
         if (!empty($this->config->ignoresecurity)) {
             $settings['ignoresecurity'] = true;

--- a/classes/api/client.php
+++ b/classes/api/client.php
@@ -78,7 +78,7 @@ class client {
         $this->apikey = $apikey;
 
         $this->baseurl = trim($baseurl, '/');
-        $this->apiurl = $baseurl . '/api';
+        $this->apiurl = $this->baseurl . '/api';
 
         if (!filter_var($this->apiurl, FILTER_VALIDATE_URL)) {
             throw new api_exception('error_config_has_no_valid_baseurl');

--- a/classes/api/client.php
+++ b/classes/api/client.php
@@ -98,8 +98,8 @@ class client {
 
         // Should the certificate be verified.
         if (empty($this->config->check_ssl)) {
-            $curloptions['CURLOPT_SSL_VERIFYHOST'] = 0;
-            $curloptions['CURLOPT_SSL_VERIFYPEER'] = 0;
+            $this->curloptions['CURLOPT_SSL_VERIFYHOST'] = 0;
+            $this->curloptions['CURLOPT_SSL_VERIFYPEER'] = 0;
         }
 
         if (empty($this->config->apiversion)) {

--- a/classes/api/test_client.php
+++ b/classes/api/test_client.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_etherpadlite\api;
+
+/**
+ * Client subclass exposing some protected members to make it testable.
+ *
+ * @package     mod_etherpadlite
+ * @author      Daniil Fajnberg <d.fajnberg@tu-berlin.de>
+ * @copyright   2023 Daniil Fajnberg
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class test_client extends client {
+    /** @var string */
+    public $apikey = '';
+    /** @var string */
+    public $baseurl = '';
+    /** @var string */
+    public $apiurl = '';
+    /** @var \curl */
+    public $curl;
+    /** @var \stdClass */
+    public $config;
+    /** @var array */
+    public $curloptions;
+
+    /**
+     * Constructor made public.
+     *
+     * @param string $apikey
+     * @param string $baseurl
+     */
+    public function __construct($apikey, $baseurl) {
+        parent::__construct($apikey, $baseurl);
+    }
+}

--- a/tests/api_client_test.php
+++ b/tests/api_client_test.php
@@ -1,0 +1,170 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for the API client.
+ *
+ * @package     mod_etherpadlite
+ * @category    test
+ * @author      Daniil Fajnberg <d.fajnberg@tu-berlin.de>
+ * @copyright   2023 Daniil Fajnberg
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_etherpadlite;
+
+use advanced_testcase;
+use curl;
+use mod_etherpadlite\api\api_exception;
+use mod_etherpadlite\api\client;
+use mod_etherpadlite\api\test_client;
+
+/**
+ * Unit tests for the API client.
+ *
+ * @package     mod_etherpadlite
+ * @category    test
+ * @author      Daniil Fajnberg <d.fajnberg@tu-berlin.de>
+ */
+class api_client_test extends advanced_testcase {
+    /**
+     * Test constructing a client instance.
+     *
+     * @covers \mod_etherpadlite\api\client::__construct()
+     * @return void
+     */
+    public function test_construct() {
+        $apikey = 'foo';
+        $baseurl = 'https://example.com';
+        // Purposefully add a trailing slash to the URL.
+        $test_client = new test_client($apikey, $baseurl . '/');
+        $this->assertEquals($baseurl, $test_client->baseurl);
+        // Ensure the `apiurl` path was properly concatenated (with a single slash).
+        $this->assertEquals($baseurl . '/api', $test_client->apiurl);
+        // Check the rest of the relevant property assignments.
+        $this->assertEquals($apikey, $test_client->apikey);
+        $this->assertInstanceOf(curl::class, $test_client->curl);
+        $this->assertEquals(
+            client::DEFAULT_CONNECTTIMEOUT,
+            $test_client->curloptions['CURLOPT_CONNECTTIMEOUT'],
+        );
+        $this->assertEquals(
+            client::DEFAULT_TIMEOUT,
+            $test_client->curloptions['CURLOPT_TIMEOUT'],
+        );
+        $this->assertEquals(
+            client::DEFAULT_API_VERSION,
+            $test_client->config->apiversion,
+        );
+    }
+
+    /**
+     * Test successfully validating a client configuration.
+     *
+     * @covers \mod_etherpadlite\api\client::validate()
+     * @return void
+     * @throws api_exception
+     */
+    public function test_validate_passes() {
+        $test_client = $this->getMockBuilder(test_client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['check_version', 'check_token'])
+            ->getMock();
+        $test_client->apikey = 'not empty';
+        $test_client->apiurl = 'https://some.valid.url';
+        $version = 'something';
+        $test_client->config = (object)['apiversion' => $version];
+        $test_client->expects($this->exactly(2))
+            ->method('check_version')
+            ->withConsecutive([$version], ['1.2', $version])
+            ->willReturnCallback(fn($_, $usedversion=null) => is_null($usedversion));
+        $test_client->expects($this->never())->method('check_token');
+        $test_client->validate();
+    }
+
+    /**
+     * Test client config validation error due to the API token not passing the check.
+     *
+     * @covers \mod_etherpadlite\api\client::validate()
+     * @return void
+     */
+    public function test_validate_invalid_key() {
+        $test_client = $this->getMockBuilder(test_client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['check_version', 'check_token'])
+            ->getMock();
+        $test_client->apikey = 'not empty';
+        $test_client->apiurl = 'https://some.valid.url';
+        $version = 'something';
+        $test_client->config = (object)['apiversion' => $version];
+        $test_client->expects($this->exactly(2))
+            ->method('check_version')
+            ->withConsecutive([$version], ['1.2', $version])
+            ->willReturn(true);
+        $test_client->expects($this->once())
+            ->method('check_token')
+            ->willReturn(false);
+        $this->expectException(api_exception::class);
+        $test_client->validate();
+    }
+
+    /**
+     * Test client config validation error due to wrong API version.
+     *
+     * @covers \mod_etherpadlite\api\client::validate()
+     * @return void
+     */
+    public function test_validate_wrong_version() {
+        $test_client = $this->getMockBuilder(test_client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['check_version', 'check_token'])
+            ->getMock();
+        $test_client->apikey = 'not empty';
+        $test_client->apiurl = 'https://some.valid.url';
+        $version = 'something';
+        $test_client->config = (object)['apiversion' => $version];
+        $test_client->expects($this->once())
+            ->method('check_version')
+            ->with($version)
+            ->willReturn(false);
+        $test_client->expects($this->never())->method('check_token');
+        $this->expectException(api_exception::class);
+        $test_client->validate();
+    }
+
+    /**
+     * Test client config validation error due to an invalid API url or missing key.
+     *
+     * @covers \mod_etherpadlite\api\client::validate()
+     * @return void
+     */
+    public function test_validate_invalid_url_or_missing_key() {
+        $test_client = $this->getMockBuilder(test_client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['check_version', 'check_token'])
+            ->getMock();
+        $test_client->apikey = 'not empty';
+        $test_client->apiurl = 'https://not a valid.url';
+        $test_client->expects($this->never())->method('check_version');
+        $test_client->expects($this->never())->method('check_token');
+        $this->expectException(api_exception::class);
+        $test_client->validate();
+
+        $test_client->apikey = '';
+        $test_client->apiurl = 'https://some.valid.url';
+        $test_client->validate();
+    }
+}


### PR DESCRIPTION
The main objective was to re-introduce a slash-trimmed base URL for constructing the API URL.

A bug was introduced [here in a recent commit](https://github.com/moodlehu/moodle-mod_etherpadlite/commit/2bc50a04b03b4e1e05f115a15d4d77ea79565a29#diff-ae6a773bbf9167f4105e15d79d393c34747915a153f88b920825e507ca78473aR81) that caused an invalid API URL to be created, if the base URL in the config ended in a slash.

Instead of this

https://github.com/moodlehu/moodle-mod_etherpadlite/blob/8b4112fcb53992e40a05e98584a9a5a5433eeb3e/classes/api/client.php#L80-L81

it should be this

```php
        $this->baseurl = trim($baseurl, '/');
        $this->apiurl = $this->baseurl . '/api';
```

Depending on the server settings, this may cause a request to not get processed properly.

---

This seemed like a very cheap thing to fix for a merge request, so I thought I'd go the extra mile and also add a few tests and minor refactoring/fixes for the `client` constructor.

Since there is no way to mock an object's methods in PHP _before_ it is constructed (unlike in Python for example), I had to get creative and get rid of the `check_version` method calls from the constructor.

As putting complex logic (and especially external API calls) in a constructor is generally probably a bad idea anyway, I thought a separate `validate` method would make sense. So I put all the validation logic in there and made the `get_instance` static method call it after creation (in the non-testing case).

To allow for easier testing, I subclassed the `client` and exposed its protected properties and constructor.

Also, the `check_ssl` config was not properly handled (discarded in the negative case).