### PR TITLE
Correct button classes in activity overview.

### DIFF
--- a/classes/courseformat/overview.php
+++ b/classes/courseformat/overview.php
@@ -51,11 +51,21 @@ class overview extends \core_courseformat\activityoverviewbase {
             ['id' => $this->cm->id],
         );
 
+        if (
+            class_exists(button::class) &&
+            (new \ReflectionClass(button::class))->hasConstant('BODY_OUTLINE')
+        ) {
+            $bodyoutline = button::BODY_OUTLINE;
+            $buttonclass = $bodyoutline->classes();
+        } else {
+            $buttonclass = "btn btn-outline-secondary";
+        }
+
         $text = get_string('view');
         $content = new action_link(
             url: $url,
             text: $text,
-            attributes: ['class' => button::BODY_OUTLINE->classes()],
+            attributes: ['class' => $buttonclass],
         );
 
         return new overviewitem(


### PR DESCRIPTION
All activities use button::BODY_OUTLINE, not button::SECONDARY_OUTLINE, actually.
Moodle 5.0 which hasn't button::BODY_OUTLINE will use "btn btn-outline-secondary" (this equals to button::SECONDARY_OUTLINE)